### PR TITLE
Replaces manual protobuf build with Python packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The super-user api key should be removed from the users.yml file for a new insta
 
 ### OS/Ansible versions
 
-This is being tested on Ubuntu 16.04.3 LTS and Ansible 2.4.
+Currently only Ubuntu is supported. This is being tested on Ubuntu 16.04.3 LTS and Ansible 2.4.
 
 ### Server credentials
 
@@ -59,8 +59,8 @@ ubuntu
 Two users are built, one super-admin and one admin in the default organization.  The configuration for these users is in:
 
 ```
-inventory/tyk_dashboard/users.yml
-inventory/tyk_dashboard/organisation.yml
+inventory/group_vars/tyk_dashboard/users.yml
+inventory/group_vars/tyk_dashboard/organisation.yml
 ```
 
 ### Building the example python middleware
@@ -82,7 +82,7 @@ A role called site_config exists which may contain changes and/or software speci
 ### Usage
 
 ```shell
-➜  tyk-ansible git:(master) ✗ ansible-playbook -i inventory site.yml
+➜  tyk-ansible git:(master) ✗ ansible-playbook -i inventory/inventory.txt site.yml
 
 PLAY [all] *********************************************************************
 

--- a/roles/tyk_python/tasks/main.yml
+++ b/roles/tyk_python/tasks/main.yml
@@ -53,78 +53,15 @@
   - libpython3.4m.so
   - libpython3.4m.so.1.0
 
-#### Install the
-#### https://developers.google.com/protocol-buffers/docs/reference/python-generated#cpp_impl
-
-- name: Check if libprotobuf.so is installed
-  stat:
-    path: /usr/lib/libprotobuf.so
-  register: libprotobuf
-
-- block:
-
-  - name: Fetch the latest protocol buffer library
-    get_url:
-      url:   https://github.com/google/protobuf/releases/download/v3.4.1/protobuf-python-3.4.1.tar.gz
-      dest: /usr/src/protobuf-python-3.4.1.tar.gz
-
-  - name: Untar the file
-    shell: tar -xvzf protobuf-python-3.4.1.tar.gz
-    args:
-      chdir: /usr/src
-
-  - name: Configure the protocol buffer library
-    shell: ./configure -prefix=/usr
-    args:
-      chdir: /usr/src/protobuf-3.4.1
-
-  - name: Make protobuf-3.4.1
-    make:
-      chdir: /usr/src/protobuf-3.4.1
-
-  - name: Make install protobuf-3.4.1
-    make:
-      chdir: /usr/src/protobuf-3.4.1
-      target: install
-
-  - name: Build and install the Python module
-    shell: export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp && python3.4 setup.py build --cpp_implementation && python3.4 setup.py install --cpp_implementation
-    args:
-      chdir: /usr/src/protobuf-3.4.1/python
-
-  when: not libprotobuf.stat.exists
-
-- name: Run pip3 to check if protobuf==3.4.1 is installed
-  shell: pip3.4 freeze
-  register: pip3_freeze
-  changed_when: false
-
-- debug: var=pip3_freeze
+- name: Install protobuf
+  pip:
+    name: protobuf
+    executable: pip3.4
 
 - name: Install HTTP/2-based RPC framework
   pip:
     name: grpcio
     executable: pip3.4
-#
-# - name: Install python3-setuptools
-#   apt:
-#     name: python3-setuptools
-#     state: present
-#
-# - name: Install python3-dev
-#   apt:
-#     name: python3-dev
-#     state: present
-#
-# - name: Run pip3 to check if protobuf==3.1.0 is installed
-#   shell: pip3.4 freeze
-#   register: pip3_freeze
-#   changed_when: false
-
-# - debug: var=pip3_freeze
-
-
-
 
 - name: Give the tyk-gateway-lua service a unique name
   lineinfile:


### PR DESCRIPTION
Manually building protobuf and its Python extension isn't required since Google distributes Python protobuf package as a "wheel" (i.e. a binary compilation). This wheel is assembled with C++ extension, which links libprotobuf statically into it. This way it doesn't depend on having a runtime in the system. With this change it's possible to provision the whole Tyk on-prem stack even on a most basic DigitalOcean instance.

In addition to this, readme instructions are a bit actualised.